### PR TITLE
/tuio2/chg and /tuio2/ocg handling via TuioGeometry

### DIFF
--- a/TUIO2/TuioClient.h
+++ b/TUIO2/TuioClient.h
@@ -202,6 +202,50 @@ namespace TUIO2 {
          */
          using TuioDispatcher::getTuioSymbolList;
          std::list<TuioSymbol*> getTuioSymbolList(unsigned int src_id);
+		
+		/**
+		 * Returns the convex hull geometry object corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active geometry
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding convex hull geometry object
+		 * @return  an active convex hull geometry object corresponding to the provided Session ID or NULL
+		 */
+		using TuioDispatcher::getTuioCHG;
+		TuioGeometry* getTuioCHG(unsigned int src_id, unsigned int s_id);
+		
+		/**
+		 * Returns a List of all currently active convex hull geometry objects
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of convex hull geometry objects
+		 */
+		using TuioDispatcher::getTuioCHGList;
+		std::list<TuioSymbol*> getTuioCHGList(unsigned int src_id);
+		
+		/**
+		 * Returns the outer contour geometry object corresponding to the provided Session ID
+		 * which is associated to the given Source ID
+		 * or NULL if the Session ID does not refer to an active geometry
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @param  s_id  the session ID of the corresponding outer contour geometry object
+		 * @return  an active outer contour geometry object corresponding to the provided Session ID or NULL
+		 */
+		using TuioDispatcher::getTuioOCG;
+		TuioGeometry* getTuioOCG(unsigned int src_id, unsigned int s_id);
+		
+		/**
+		 * Returns a List of all currently active outer contour geometry objects
+		 * which are associated to the given Source ID
+		 *
+		 * @param  src_id  the source ID of the corresponding TUIO source
+		 * @return  a List of outer contour geometry objects
+		 */
+		using TuioDispatcher::getTuioOCGList;
+		std::list<TuioSymbol*> getTuioOCGList(unsigned int src_id);
 
         /**
          * Parses the incoming OSC message

--- a/TUIO2/TuioDispatcher.cpp
+++ b/TUIO2/TuioDispatcher.cpp
@@ -110,6 +110,20 @@ TuioSymbol* TuioDispatcher::getTuioSymbol(unsigned int s_id) {
     return tobj->getTuioSymbol();
 }
 
+TuioGeometry* TuioDispatcher::getTuioCHG(unsigned int s_id) {
+	TuioObject *tobj = getTuioObject(s_id);
+	if (tobj==NULL) return NULL;
+	
+	return tobj->getTuioCHG();
+}
+
+TuioGeometry* TuioDispatcher::getTuioOCG(unsigned int s_id) {
+	TuioObject *tobj = getTuioObject(s_id);
+	if (tobj==NULL) return NULL;
+	
+	return tobj->getTuioOCG();
+}
+
 std::list<TuioObject*> TuioDispatcher::getTuioObjectList() {
     std::list<TuioObject*> listBuffer;
     lockObjectList();
@@ -162,4 +176,26 @@ std::list<TuioSymbol*> TuioDispatcher::getTuioSymbolList() {
     }
     unlockObjectList();
     return listBuffer;
+}
+
+std::list<TuioGeometry*> TuioDispatcher::getTuioCHGList() {
+	std::list<TuioGeometry*> listBuffer;
+	lockObjectList();
+	for (std::list<TuioObject*>::iterator tobj=tobjList.begin(); tobj!=tobjList.end(); tobj++) {
+		TuioGeometry *tgeom = (*tobj)->getTuioCHG();
+		if (tgeom!=NULL) listBuffer.push_back(tgeom);
+	}
+	unlockObjectList();
+	return listBuffer;
+}
+
+std::list<TuioGeometry*> TuioDispatcher::getTuioOCGList() {
+	std::list<TuioGeometry*> listBuffer;
+	lockObjectList();
+	for (std::list<TuioObject*>::iterator tobj=tobjList.begin(); tobj!=tobjList.end(); tobj++) {
+		TuioGeometry *tgeom = (*tobj)->getTuioOCG();
+		if (tgeom!=NULL) listBuffer.push_back(tgeom);
+	}
+	unlockObjectList();
+	return listBuffer;
 }

--- a/TUIO2/TuioDispatcher.h
+++ b/TUIO2/TuioDispatcher.h
@@ -103,7 +103,21 @@ namespace TUIO2 {
          * @return  a List of all currently active TuioSymbols
          */
         std::list<TuioSymbol*> getTuioSymbolList();
+		
+		/**
+		 * Returns a List of all currently active convex hull geometries
+		 *
+		 * @return  a List of all currently active convex hull geometries
+		 */
+		std::list<TuioGeometry*> getTuioCHGList();
 
+		/**
+		 * Returns a List of all currently active outer contour geometries
+		 *
+		 * @return  a List of all currently active outer contour geometries
+		 */
+		std::list<TuioGeometry*> getTuioOCGList();
+		
         /**
          * Returns the TuioObject corresponding to the provided Session ID
          * or NULL if the Session ID does not refer to an active TuioObject
@@ -143,6 +157,22 @@ namespace TUIO2 {
          * @return  an active TuioSymbol corresponding to the provided Session ID or NULL
          */
         TuioSymbol* getTuioSymbol(unsigned int s_id);
+		
+		/**
+		 * Returns the convex hull geometry corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active convex hull geometry
+		 *
+		 * @return  an active convex hull geometry corresponding to the provided Session ID or NULL
+		 */
+		TuioGeometry* getTuioCHG(unsigned int s_id);
+		
+		/**
+		 * Returns the outer contour geometry corresponding to the provided Session ID
+		 * or NULL if the Session ID does not refer to an active outer contour geometry
+		 *
+		 * @return  an active outer contour geometry corresponding to the provided Session ID or NULL
+		 */
+		TuioGeometry* getTuioOCG(unsigned int s_id);
 		
 		/**
 		 * Locks the TuioObject list in order to avoid updates during access

--- a/TUIO2/TuioGeometry.cpp
+++ b/TUIO2/TuioGeometry.cpp
@@ -1,0 +1,84 @@
+/*
+ TUIO2 C++ Library
+ Copyright (c) 2009-2014 Martin Kaltenbrunner <martin@tuio.org>
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+ */
+
+#include "TuioGeometry.h"
+#include "TuioObject.h"
+using namespace TUIO2;
+
+TuioGeometry::TuioGeometry (TuioTime ttime, TuioObject *tobj, std::list<TuioPoint> tpoints):state(TUIO_ADDED) {
+	container = tobj;
+	points.assign(tpoints.begin(), tpoints.end());
+	currentTime = ttime;
+	startTime = currentTime;
+}
+
+TuioGeometry::TuioGeometry (TuioObject *tobj, std::list<TuioPoint> tpoints):state(TUIO_ADDED) {
+	container = tobj;
+	points.assign(tpoints.begin(), tpoints.end());
+	currentTime = TuioTime::getSystemTime();
+	startTime = currentTime;
+	
+}
+
+TuioGeometry::TuioGeometry (TuioGeometry *tgeom):state(TUIO_ADDED)
+{
+	container = tgeom->getContainingTuioObject();
+	points.assign(tgeom->getPoints().begin(), tgeom->getPoints().end());
+}
+
+TuioObject* TuioComponent::getContainingTuioObject() {
+	return container;
+}
+
+void TuioGeometry::update(TuioTime ttime, std::list<TuioPoint> tpoints) {
+	points.assign(tpoints.begin(), tpoints.end());
+	currentTime = ttime;
+}
+
+void TuioGeometry::update(std::list<TuioPoint> tpoints) {
+	points.assign(tpoints.begin(), tpoints.end());
+}
+
+void TuioGeometry::update(TuioGeometry *tgeom) {
+	points.assign(tgeom->getPoints().begin(), tgeom->getPoints().end());
+}
+
+void TuioComponent::remove(TuioTime ttime) {
+	currentTime = ttime;
+	state = TUIO_REMOVED;
+}
+
+unsigned int TuioGeometry::getSessionID() const{
+	return container->getSessionID();
+}
+
+std::list<TuioPoint> TuioGeometry::getPoints() const {
+	return points;
+}
+
+int TuioGeometry::getTuioState() const{
+	return state;
+}
+
+TuioTime TuioGeometry::getTuioTime() const{
+	return currentTime;
+}
+
+TuioTime TuioGeometry::getStartTime() const{
+	return startTime;
+}

--- a/TUIO2/TuioGeometry.h
+++ b/TUIO2/TuioGeometry.h
@@ -1,0 +1,178 @@
+/*
+ TUIO2 C++ Library
+ Copyright (c) 2009-2014 Martin Kaltenbrunner <martin@tuio.org>
+ 
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3.0 of the License, or (at your option) any later version.
+ 
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+ 
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library.
+ */
+
+#ifndef INCLUDED_TUIOGEOMETRY_H
+#define INCLUDED_TUIOGEOMETRY_H
+
+#include "TuioPoint.h"
+#include "TuioTime.h"
+
+#include <list>
+#include <string>
+
+#define TUIO_IDLE 0
+#define TUIO_ADDED 1
+#define TUIO_ACCELERATING 2
+#define TUIO_DECELERATING 3
+#define TUIO_ROTATING 4
+#define TUIO_STOPPED 5
+#define TUIO_REMOVED 6
+
+namespace TUIO2 {
+	
+	/**
+	 * The abstract TuioGeometry class defines common attributes that apply to all subclasses {@link TuioOCG}.
+	 *
+	 * @author Ivan Dilchovski
+	 * @version 2.0.a0
+	 */
+	
+	class TuioObject;
+	class LIBDECL TuioGeometry {
+		
+	protected:
+		/**
+		 * The TuioObject that contains this TUIO geometry.
+		 */
+		TuioObject *container;
+		/**
+		 * The list containing the points defining the geometry
+		 */
+		std::list<TuioPoint> points;
+		/**
+		 * The time stamp of the last update represented as TuioTime (time since session start)
+		 */
+		TuioTime currentTime;
+		/**
+		 * The creation time of this TuioPoint represented as TuioTime (time since session start)
+		 */
+		TuioTime startTime;
+		/**
+		 * Reflects the current state of the TuioComponent
+		 */
+		int state;
+		
+	public:
+		using TuioPoint::update;
+		
+		/**
+		 * This constructor takes a TuioTime argument and assigns it along with the provided
+		 * Session ID and list of geometry points to the newly created TuioComponent.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	tobj	the TuioObject to assign
+		 * @param	tpoints	the TuioPoints forming the basic geometry
+		 */
+		TuioGeometry (TuioTime ttime, TuioObject *tobj, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * This constructor takes the provided Session ID and
+		 * list of geometry points to the newly created TuioComponent.
+		 *
+		 * @param	tobj	the TuioObject to assign
+		 * @param	tpoints	the TuioPoints forming the basic geometry
+		 */
+		TuioGeometry (TuioObject *tobj, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * This constructor takes the atttibutes of the provided TuioGeometry
+		 * and assigs these values to the newly created TuioGeometry.
+		 *
+		 * @param	tcon	the TuioGeometry to assign
+		 */
+		TuioGeometry (TuioGeometry *tgeom);
+		
+		/**
+		 * The destructor is doing nothing in particular.
+		 */
+		virtual ~TuioGeometry(){};
+		
+		/**
+		 * Returns the TuioObject containing this TuioGeometry.
+		 * @return	the TuioObject containing this TuioGeometry
+		 */
+		virtual TuioObject* getContainingTuioObject();
+		
+		/**
+		 * Takes a TuioTime argument and assigns it along with the provided
+		 * list of points to the private TuioComponent attributes.
+		 * The speed and accleration values are calculated accordingly.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 * @param	tpoints tpoints	the TuioPoints forming the basic geometry
+		 */
+		virtual void update (TuioTime ttime, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Assigns the provided list of geometry points
+		 * to the private TuioGeometry attributes. The TuioTime time stamp remains unchanged.
+		 *
+		 * @param	tpoints tpoints	the TuioPoints forming the basic geometry
+		 */
+		virtual void update (std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Takes the atttibutes of the provided TuioGeometry
+		 * and assigs these values to this TuioGeometry.
+		 * The TuioTime time stamp of this TuioGeometry remains unchanged.
+		 *
+		 * @param	tcon	the TuioGeometry to assign
+		 */
+		virtual void update(TuioGeometry *tgeom);
+		
+		/**
+		 * Assigns the REMOVE state to this TuioGeometry and sets
+		 * its TuioTime time stamp to the provided TuioTime argument.
+		 *
+		 * @param	ttime	the TuioTime to assign
+		 */
+		virtual void remove(TuioTime ttime);
+		
+		/**
+		 * Returns the Session ID of this TuioGeometry.
+		 * @return	the Session ID of this TuioGeometry
+		 */
+		virtual unsigned int getSessionID() const;
+		
+		/**
+		 * Returns the points of this TuioGeometry.
+		 * @return	the points of this TuioGeometry
+		 */
+		virtual std::list<TuioPoint> getPoints() const;
+		
+		/**
+		 * Returns the TUIO state of this TuioComponent.
+		 * @return	the TUIO state of this TuioComponent
+		 */
+		virtual int getTuioState() const;
+		
+		/**
+		 * Returns current time stamp of this TuioGeometry as TuioTime
+		 *
+		 * @return	the  time stamp of this TuioGeometry as TuioTime
+		 */
+		virtual TuioTime getTuioTime() const;
+		/**
+		 * Returns the start time of this TuioGeometry as TuioTime.
+		 *
+		 * @return	the start time of this TuioGeometry as TuioTime
+		 */
+		virtual TuioTime getStartTime() const;
+	};
+}
+#endif // INCLUDED_TUIOCOMPONENT_H

--- a/TUIO2/TuioManager.cpp
+++ b/TUIO2/TuioManager.cpp
@@ -123,7 +123,17 @@ void TuioManager::removeTuioObject(TuioObject *tobj) {
         if (verbose) std::cout << "del sym " << tobj->getSessionID() << std::endl;
         tobj->deleteTuioSymbol();
     }
-    
+
+	if (tobj->containsTuioCHG()) {
+		if (verbose) std::cout << "del chg " << tobj->getSessionID() << std::endl;
+		tobj->deleteTuioCHG();
+	}
+
+	if (tobj->containsTuioOCG()) {
+		if (verbose) std::cout << "del ocg " << tobj->getSessionID() << std::endl;
+		tobj->deleteTuioOCG();
+	}
+	
     tobjList.remove(tobj);
     tobjUpdate = true;
     delete tobj;
@@ -650,6 +660,214 @@ void TuioManager::removeTuioSymbol(TuioSymbol *tsym) {
     } else removeTuioObject(tobj);
 }
 
+TuioObject* TuioManager::createTuioCHG(std::list<TuioPoint> tpoints) {
+	sessionID++;
+	TuioObject *tobj = new TuioObject(sessionID);
+	
+	TuioGeometry *tchg = new TuioGeometry(currentFrameTime, tobj, tpoints);
+	tobj->setTuioCHG(tchg);
+	tobjList.push_back(tobj);
+	tobjUpdate = true;
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->tuioAdd(tobj);
+	
+	if (verbose)std::cout << "add chg " << tobj->getSessionID() << std::endl;
+	
+	return tobj;
+}
+
+TuioObject* TuioManager::addTuioCHG(unsigned int s_id, std::list<TuioPoint> tpoints) {
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==s_id) {
+			tobj = *iter;
+			break;
+		}
+	}
+	if (tobj==NULL) return NULL;
+	
+	TuioGeometry *tchg = new TuioGeometry(tobj, tpoints);
+	tobj->setTuioCHG(tchg);
+	tobjUpdate = true;
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->tuioAdd(tobj);
+	
+	if (verbose)std::cout << "add chg " << tobj->getSessionID() << std::endl;
+	
+	return tobj;
+}
+
+TuioObject* TuioManager::addTuioCHG(TuioGeometry *tchg) {
+	if (tchg==NULL) return NULL;
+	
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==tchg->getSessionID()) {
+			tobj = *iter;
+			break;
+		}
+	}
+	
+	if (tobj!=NULL) tobjUpdate = true;
+	else tobj = new TuioObject(tchg->getSessionID());
+	tobj->setTuioCHG(tchg);
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++) {
+		if (tobjUpdate)(*listener)->tuioUpdate(tobj);
+		else(*listener)->tuioAdd(tobj);
+	}
+	
+	if (verbose) std::cout << "add chg " << tobj->getSessionID() << std::endl;
+	tobjUpdate = true;
+	
+	return tobj;
+}
+
+void TuioManager::updateTuioCHG(TuioGeometry *tchg, std::list<TuioPoint> tpoints) {
+	if (tchg==NULL) return;
+	if (tchg->getTuioTime()==currentFrameTime) return;
+	
+	
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==tchg->getSessionID()) {
+			tobj = *iter;
+			break;
+		}
+	}
+	
+	tchg->update(currentFrameTime, tpoints);
+	tobjUpdate = true;
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->tuioUpdate(tobj);
+	
+	if (verbose)std::cout << "set chg " << tobj->getSessionID() << std::endl;
+}
+
+void TuioManager::removeTuioCHG(TuioGeometry *tchg) {
+	if (tchg==NULL) return;
+	
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==tchg->getSessionID()) {
+			tobj = *iter;
+			break;
+		}
+	}
+	
+	if (tobj==NULL) {
+		delete tchg;
+		return;
+	} else removeTuioObject(tobj);
+}
+
+TuioObject* TuioManager::createTuioOCG(std::list<TuioPoint> tpoints) {
+	sessionID++;
+	TuioObject *tobj = new TuioObject(sessionID);
+	
+	TuioGeometry *tocg = new TuioGeometry(currentFrameTime, tobj, tpoints);
+	tobj->setTuioOCG(tocg);
+	tobjList.push_back(tobj);
+	tobjUpdate = true;
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->tuioAdd(tobj);
+	
+	if (verbose)std::cout << "add ocg " << tobj->getSessionID() << std::endl;
+	
+	return tobj;
+}
+
+TuioObject* TuioManager::addTuioOCG(unsigned int s_id, std::list<TuioPoint> tpoints) {
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==s_id) {
+			tobj = *iter;
+			break;
+		}
+	}
+	if (tobj==NULL) return NULL;
+	
+	TuioGeometry *tocg = new TuioGeometry(tobj, tpoints);
+	tobj->setTuioOCG(tocg);
+	tobjUpdate = true;
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->tuioAdd(tobj);
+	
+	if (verbose)std::cout << "add ocg " << tobj->getSessionID() << std::endl;
+	
+	return tobj;
+}
+
+TuioObject* TuioManager::addTuioOCG(TuioGeometry *tocg) {
+	if (tocg==NULL) return NULL;
+	
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==tocg->getSessionID()) {
+			tobj = *iter;
+			break;
+		}
+	}
+	
+	if (tobj!=NULL) tobjUpdate = true;
+	else tobj = new TuioObject(tocg->getSessionID());
+	tobj->setTuioCHG(tocg);
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++) {
+		if (tobjUpdate)(*listener)->tuioUpdate(tobj);
+		else(*listener)->tuioAdd(tobj);
+	}
+	
+	if (verbose) std::cout << "add ocg " << tobj->getSessionID() << std::endl;
+	tobjUpdate = true;
+	
+	return tobj;
+}
+
+void TuioManager::updateTuioOCG(TuioGeometry *tocg, std::list<TuioPoint> tpoints) {
+	if (tocg==NULL) return;
+	if (tocg->getTuioTime()==currentFrameTime) return;
+	
+	
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==tocg->getSessionID()) {
+			tobj = *iter;
+			break;
+		}
+	}
+	
+	tocg->update(currentFrameTime, tpoints);
+	tobjUpdate = true;
+	
+	for (std::list<TuioListener*>::iterator listener=listenerList.begin(); listener != listenerList.end(); listener++)
+		(*listener)->tuioUpdate(tobj);
+	
+	if (verbose)std::cout << "set ocg " << tobj->getSessionID() << std::endl;
+}
+
+void TuioManager::removeTuioOCG(TuioGeometry *tocg) {
+	if (tocg==NULL) return;
+	
+	TuioObject *tobj = NULL;
+	for(std::list<TuioObject*>::iterator iter = tobjList.begin();iter!= tobjList.end(); iter++) {
+		if((*iter)->getSessionID()==tocg->getSessionID()) {
+			tobj = *iter;
+			break;
+		}
+	}
+	
+	if (tobj==NULL) {
+		delete tocg;
+		return;
+	} else removeTuioObject(tobj);
+}
+
 int TuioManager::getSessionID() {
 	sessionID++;
     if (sessionID==UINT_MAX) sessionID = 0;
@@ -753,7 +971,15 @@ std::list<TuioObject*> TuioManager::getUntouchedObjects() {
         if ((*tobj)->containsTuioSymbol()) {
             if ((*tobj)->getTuioSymbol()->getTuioTime()==currentFrameTime) touched=true;
         }
-        
+		
+		if ((*tobj)->containsTuioCHG()) {
+			if ((*tobj)->getTuioCHG()->getTuioTime()==currentFrameTime) touched=true;
+		}
+
+		if ((*tobj)->containsTuioOCG()) {
+			if ((*tobj)->getTuioOCG()->getTuioTime()==currentFrameTime) touched=true;
+		}
+		
         if (!touched) untouched.push_back(*tobj);
 		
 	}	

--- a/TUIO2/TuioManager.h
+++ b/TUIO2/TuioManager.h
@@ -163,10 +163,11 @@ namespace TUIO2 {
         TuioObject* addTuioToken(unsigned int s_id, unsigned short t_id, unsigned short u_id, unsigned int sym, float xp, float yp, float a);
         
         /**
-         * Creates a new TuioToken based on the given arguments.
-         * and adds it to an existing TuioObject with the Session ID
-         * from the TuioServer's internal list of TuioObjects
-         * and the TuioToken reference is returned to the caller.
+		 * Creates a new TuioToken based on the given arguments
+		 * and adds it to an existing TuioObject with the Session ID
+		 * from the TuioServer's internal list of TuioObjects.
+		 * The new TuioToken is added to the TuioServer's internal list of active TuioTokens
+		 * The TuioToken reference is returned to the caller.
          *
          * @param	s_id	the Session ID of the existing TuioObject
          * @param	t_id	the Type ID to assign
@@ -223,10 +224,11 @@ namespace TUIO2 {
 		TuioObject* createTuioPointer(float xp, float yp, float a, float s, float r, float p);
         
         /**
-         * Creates a new TuioPointer based on the given arguments.
-         * and adds it to an existing TuioObject with the Session ID
-         * The new TuioPointer is added to the TuioServer's internal list of active TuioPointers
-         * and a reference of the TuioObject is returned to the caller.
+		 * Creates a new TuioPointer based on the given arguments
+		 * and adds it to an existing TuioObject with the Session ID
+		 * from the TuioServer's internal list of TuioObjects.
+		 * The new TuioPointer is added to the TuioServer's internal list of active TuioPointers
+		 * The TuioPointer reference is returned to the caller.
          *
          * @param	s_id	the Session ID of the existing TuioObject
          * @param	xp	the X coordinate to assign
@@ -392,10 +394,13 @@ namespace TUIO2 {
 		TuioObject* createTuioBounds(float xp, float yp, float angle, float width, float height, float area);
         
         /**
-         * Creates a new TuioBounds based on the given arguments.
-         * The new TuioBounds is added to the TuioServer's internal list of active TuioBounds
-         * and a reference is returned to the caller.
-         *
+		 * Creates a new TuioBounds based on the given arguments
+		 * and adds it to an existing TuioObject with the Session ID
+		 * from the TuioServer's internal list of TuioObjects.
+		 * The new TuioBounds is added to the TuioServer's internal list of active TuioBounds
+		 * The TuioBounds reference is returned to the caller.
+		 *
+		 * @param	s_id	the Session ID of the existing TuioObject
          * @param	xp	the X coordinate to assign
          * @param	yp	the Y coordinate to assign
          * @param	angle	the angle to assign
@@ -451,11 +456,14 @@ namespace TUIO2 {
          */
         TuioObject* createTuioSymbol(unsigned short t_id, unsigned short u_id, unsigned int sym, const char *type, const char *data);
         
-        /**
-         * Creates a new TuioSymbol based on the given arguments.
-         * The new TuioSymbol is added to the TuioServer's internal list of TuioObjects
-         * and a reference is returned to the caller.
-         *
+		/**
+		 * Creates a new TuioSymbol based on the given arguments
+		 * and adds it to an existing TuioObject with the Session ID
+		 * from the TuioServer's internal list of TuioObjects.
+		 * The new TuioSymbol is added to the TuioServer's internal list of active TuioSymbol
+		 * The TuioSymbols reference is returned to the caller.
+		 *
+		 * @param	s_id	the Session ID of the existing TuioObject
          * @param	t_id	the Type ID to assign
          * @param	u_id	the User ID to assign
          * @param	sym     the Symbol ID to assign
@@ -482,6 +490,104 @@ namespace TUIO2 {
          * @param	tsym	the TuioSymbol to remove
          */
         void removeTuioSymbol(TuioSymbol *tsym);
+		
+		/**
+		 * Creates a new convex hull geometry object based on the given arguments.
+		 * The new geometry object is added to the TuioServer's internal list of active TuioBounds
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	tpoints the points forming the geometry
+		 * @return	a reference to the TuioObject of the geometry
+		 */
+		TuioObject* createTuioCHG(std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Creates a new convex hull geometry based on the given arguments
+		 * and adds it to an existing TuioObject with the Session ID
+		 * from the TuioServer's internal list of TuioObjects.
+		 * The new convex hull geometry is added to the TuioServer's internal list of active convex hull geometries
+		 * The convex hull geometry reference is returned to the caller.
+		 *
+		 * @param	s_id	the Session ID of the existing TuioObject
+		 * @param	tpoints the points forming the geometry
+		 * @return	a reference to the TuioObject of the geometry
+		 */
+		TuioObject* addTuioCHG(unsigned int s_id, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Adds the provided convex hull geometry to an existing TuioObject
+		 * from the TuioServer's internal list of TuioObjects
+		 * or creates the according TuioObject if not found.
+		 *
+		 * @param	tgeom the geometry points to be used
+		 * @return	a reference to the TuioObject of the geometry
+		 */
+		TuioObject* addTuioCHG(TuioGeometry *tchg);
+		
+		/**
+		 * Updates the referenced convex hull geometry based on the given points.
+		 *
+		 * @param	tgeom	the geometry to update
+		 * @param	tpoints the points forming the geometry
+		 */
+		void updateTuioCHG(TuioGeometry *tchg, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Removes the referenced convex hull geometry from the TuioServer's internal list of TuioObjects
+		 * and also deletes its TuioObject (and all its encapsulated TUIO Components)
+		 *
+		 * @param	tgeom	the geometry to remove
+		 */
+		void removeTuioCHG(TuioGeometry *tchg);
+		
+		/**
+		 * Creates a new outer contour geometry object based on the given arguments.
+		 * The new geometry object is added to the TuioServer's internal list of active TuioBounds
+		 * and a reference is returned to the caller.
+		 *
+		 * @param	tpoints the points forming the geometry
+		 * @return	a reference to the TuioObject of the geometry
+		 */
+		TuioObject* createTuioOCG(std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Creates a new outer contour geometry based on the given arguments
+		 * and adds it to an existing TuioObject with the Session ID
+		 * from the TuioServer's internal list of TuioObjects.
+		 * The new geometry is added to the TuioServer's internal list of active outer contour geometries
+		 * The geometry reference is returned to the caller.
+		 *
+		 * @param	s_id	the Session ID of the existing TuioObject
+		 * @param	tpoints the points forming the geometry
+		 * @return	a reference to the TuioObject of the TuioBounds
+		 */
+		TuioObject* addTuioOCG(unsigned int s_id, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Adds the provided outer contour geometry to an existing TuioObject
+		 * from the TuioServer's internal list of TuioObjects
+		 * or creates the according TuioObject if not found.
+		 *
+		 * @param	tgeom the geometry points to be used
+		 * @return	a reference to the TuioObject of the geometry
+		 */
+		TuioObject* addTuioOCG(TuioGeometry *tocg);
+		
+		/**
+		 * Updates the referenced outer contour geometry based on the given points.
+		 *
+		 * @param	tgeom	the geometry to update
+		 * @param	tpoints the points forming the geometry
+		 */
+		void updateTuioOCG(TuioGeometry *tocg, std::list<TuioPoint> tpoints);
+		
+		/**
+		 * Removes the referenced outer contour geometry from the TuioServer's internal list of TuioObjects
+		 * and also deletes its TuioObject (and all its encapsulated TUIO Components)
+		 *
+		 * @param	tgeom	the geometry to remove
+		 */
+		void removeTuioOCG(TuioGeometry *tocg);
 		
 		/**
 		 * Initializes a new frame with the given TuioTime

--- a/TUIO2/TuioObject.cpp
+++ b/TUIO2/TuioObject.cpp
@@ -97,11 +97,25 @@ void TuioObject::setTuioSymbol (TuioSymbol *tsym) {
     state = TUIO_ADDED;
 }
 
+void TuioObject::setTuioCHG(TuioGeometry *tchg) {
+	chg = tchg;
+	currentTime = TuioTime::getSystemTime();
+	state = TUIO_ADDED;
+}
+
+void TuioObject::setTuioOCG (TuioGeometry *tocg) {
+	ocg = tocg;
+	currentTime = TuioTime::getSystemTime();
+	state = TUIO_ADDED;
+}
+
 void TuioObject::removeAllTuioComponents(TuioTime ttime) {
     removeTuioToken(ttime);
     removeTuioPointer(ttime);
     removeTuioBounds(ttime);
     removeTuioSymbol(ttime);
+	removeTuioOCG(ttime);
+	removeTuioCHG(ttime);
 }
 
 void TuioObject::removeTuioToken (TuioTime ttime) {
@@ -122,6 +136,16 @@ void TuioObject::removeTuioBounds (TuioTime ttime) {
 void TuioObject::removeTuioSymbol (TuioTime ttime) {
     if (symbol != NULL) symbol->remove(ttime);
     currentTime = ttime;
+}
+
+void TuioObject::removeTuioCHG(TuioTime ttime) {
+	if (chg != NULL) chg->remove(ttime);
+	currentTime = ttime;
+}
+
+void TuioObject::removeTuioOCG(TuioTime ttime) {
+	if (ocg != NULL) ocg->remove(ttime);
+	currentTime = ttime;
 }
 
 void TuioObject::deleteAllTuioComponents() {
@@ -163,6 +187,22 @@ void TuioObject::deleteTuioSymbol () {
     }
 }
 
+void TuioObject::deleteTuioCHG () {
+	if (chg != NULL) {
+		delete chg;
+		chg = NULL;
+		//currentTime = TuioTime::getSessionTime();
+	}
+}
+
+void TuioObject::deleteTuioOCG () {
+	if (ocg != NULL) {
+		delete ocg;
+		ocg = NULL;
+		//currentTime = TuioTime::getSessionTime();
+	}
+}
+
 void TuioObject::clearAllTuioComponents() {
     clearTuioToken();
     clearTuioPointer();
@@ -198,6 +238,20 @@ void TuioObject::clearTuioSymbol () {
     }
 }
 
+void TuioObject::clearTuioCHG () {
+	if (chg != NULL) {
+		chg = NULL;
+		//currentTime = TuioTime::getSessionTime();
+	}
+}
+
+void TuioObject::clearTuioOCG () {
+	if (ocg != NULL) {
+		ocg = NULL;
+		//currentTime = TuioTime::getSessionTime();
+	}
+}
+
 bool TuioObject::containsAnyTuioComponent () {
     if (token != NULL) return true;
     else if (pointer != NULL) return true;
@@ -226,6 +280,16 @@ bool TuioObject::containsTuioSymbol () {
     else return false;
 }
 
+bool TuioObject::containsTuioCHG () {
+	if (chg != NULL) return true;
+	else return false;
+}
+
+bool TuioObject::containsTuioOCG () {
+	if (ocg != NULL) return true;
+	else return false;
+}
+
 bool TuioObject::containsNewTuioToken () {
     if (token == NULL) return false;
     else if (token->getTuioState()==TUIO_ADDED) return true;
@@ -250,6 +314,18 @@ bool TuioObject::containsNewTuioSymbol () {
     else return false;
 }
 
+bool TuioObject::containsNewTuioCHG () {
+	if (chg == NULL) return false;
+	else if (chg->getTuioState()==TUIO_ADDED) return true;
+	else return false;
+}
+
+bool TuioObject::containsNewTuioOCG () {
+	if (ocg == NULL) return false;
+	else if (ocg->getTuioState()==TUIO_ADDED) return true;
+	else return false;
+}
+
 TuioToken* TuioObject::getTuioToken () {
     return token;
 }
@@ -266,6 +342,14 @@ TuioSymbol* TuioObject::getTuioSymbol () {
     return symbol;
 }
 
+TuioGeometry* TuioObject::getTuioCHG () {
+	return chg;
+}
+
+TuioGeometry* TuioObject::getTuioOCG () {
+	return ocg;
+}
+
 void TuioObject::stop(TuioTime ttime){
     if (token!=NULL) token->stop(ttime);
     if (pointer!=NULL) pointer->stop(ttime);
@@ -277,6 +361,9 @@ void TuioObject::remove(TuioTime ttime){
     if (token!=NULL) token->remove(ttime);
     if (pointer!=NULL) pointer->remove(ttime);
     if (bounds!=NULL) bounds->remove(ttime);
+	if (symbol != NULL) symbol->remove(ttime);
+	if (chg != NULL) chg->remove(ttime);
+	if (ocg != NULL) ocg->remove(ttime);
     currentTime = ttime;
     state = TUIO_REMOVED;
 }

--- a/TUIO2/TuioObject.h
+++ b/TUIO2/TuioObject.h
@@ -25,6 +25,7 @@
 #include "TuioBounds.h"
 #include "TuioSymbol.h"
 #include "TuioSource.h"
+#include "TuioGeometry.h"
 
 namespace TUIO2 {
 	
@@ -62,9 +63,17 @@ namespace TUIO2 {
          * the associated TuioSymbol
          */
         TuioSymbol *symbol;
-        /**
-         * The time stamp of the last update represented as TuioTime (time since session start)
-         */
+		/**
+		 * the associated convex hull geometry
+		 */
+		TuioGeometry *chg;
+		/**
+		 * the associated outer contour geometry
+		 */
+		TuioGeometry *ocg;
+		/**
+		 * The time stamp of the last update represented as TuioTime (time since session start)
+		 */
         TuioTime currentTime;
 		/**
 		 * The creation time of this TuioObject represented as TuioTime (time since session start)
@@ -143,7 +152,19 @@ namespace TUIO2 {
          * @param	tsym	the TuioSymbol to assign
          */
         void setTuioSymbol(TuioSymbol *tsym);
-  
+
+		/**
+		 * This method assigns an convex hull geometry to this TuioObject
+		 * @param	tocg	the geometry to assign
+		 */
+		void setTuioCHG(TuioGeometry *tchg);
+		
+		/**
+		 * This method assigns an outer contour geometry to this TuioObject
+		 * @param	tocg	the geometry to assign
+		 */
+		void setTuioOCG(TuioGeometry *tocg);
+		
         /**
          * This method sets all TuioComponents in this TuioObject to TUIO_REMOVED state
          */
@@ -168,7 +189,17 @@ namespace TUIO2 {
          * This method sets the TuioSymbol in this TuioObject to TUIO_REMOVED state
          */
         void removeTuioSymbol(TuioTime ttime);
-        
+
+		/**
+		 * This method sets the convex hull geometry in this TuioObject to TUIO_REMOVED state
+		 */
+		void removeTuioCHG(TuioTime ttime);
+		
+		/**
+		 * This method sets the outer contour geometry in this TuioObject to TUIO_REMOVED state
+		 */
+		void removeTuioOCG(TuioTime ttime);
+		
         /**
          * This method deletes all TuioComponents in this TuioObject
          */
@@ -193,7 +224,17 @@ namespace TUIO2 {
          * This method deletes the TuioSymbol in this TuioObject
          */
         void deleteTuioSymbol();
-        
+		
+		/**
+		 * This method deletes the convex hull geometry in this TuioObject
+		 */
+		void deleteTuioCHG();
+		
+		/**
+		 * This method deletes the outer contour geometry in this TuioObject
+		 */
+		void deleteTuioOCG();
+		
         /**
          * This method clears all TuioComponents in this TuioObject
          */
@@ -218,7 +259,17 @@ namespace TUIO2 {
          * This method clears the TuioSymbol in this TuioObject
          */
         void clearTuioSymbol();
-        
+		
+		/**
+		 * This method clears the convex hull geometry in this TuioObject
+		 */
+		void clearTuioCHG();
+		
+		/**
+		 * This method clears the outer contour geometry in this TuioObject
+		 */
+		void clearTuioOCG();
+		
         /**
          * This method tests for any TuioComponent in this TuioObject
          * @return true if any TuioComponent has been assigned
@@ -248,7 +299,19 @@ namespace TUIO2 {
          * @return true if a TuioSymbol has been assigned
          */
         bool containsTuioSymbol();
-        
+		
+		/**
+		 * This method tests for an convex hull geometry in this TuioObject
+		 * @return true if an convex hull geometry has been assigned
+		 */
+		bool containsTuioCHG();
+		
+		/**
+		 * This method tests for an outer contour geometry in this TuioObject
+		 * @return true if an outer contour geometry has been assigned
+		 */
+		bool containsTuioOCG();
+		
         /**
          * This method tests if a new TuioToken has been added to this TuioObject
          * @return true if a TuioToken has been added
@@ -272,6 +335,18 @@ namespace TUIO2 {
          * @return true if a TuioSymbol has been added
          */
         bool containsNewTuioSymbol();
+		
+		/**
+		 * This method tests if a new convex hull geometry has beed added to this TuioObject
+		 * @return true if an convex hull geometry has been added
+		 */
+		bool containsNewTuioCHG();
+		
+		/**
+		 * This method tests if a new outer contour geometry has beed added to this TuioObject
+		 * @return true if an outer contour geometry has been added
+		 */
+		bool containsNewTuioOCG();
 
         /**
          * This method returns the TuioToken associated to this TuioObject
@@ -296,7 +371,19 @@ namespace TUIO2 {
          * @return	the associated TuioSymbol
          */
         TuioSymbol* getTuioSymbol();
-        
+
+		/**
+		 * This method returns the convex hull geometry associated to this TuioObject
+		 * @return	the associated convex hull geometry
+		 */
+		TuioGeometry* getTuioCHG();
+		
+		/**
+		 * This method returns the outer contour geometry associated to this TuioObject
+		 * @return	the associated outer contour geometry
+		 */
+		TuioGeometry* getTuioOCG();
+		
         /**
          * This method stops all encapsulated TuioComponents
          */

--- a/TUIO2/TuioServer.cpp
+++ b/TUIO2/TuioServer.cpp
@@ -310,6 +310,28 @@ void TuioServer::addSymbolMessage(TuioSymbol *tsym) {
     (*oscPacket) << osc::EndMessage;
 }
 
+void TuioServer::addCHGMessage(TuioGeometry *tchg) {
+	checkBundleCapacity(CHG_MESSAGE_SIZE + 8 * tchg->getPoints().size());
+	
+	(*oscPacket) << osc::BeginMessage( "/tuio2/chg");
+	(*oscPacket) << (int32)tchg->getSessionID();
+	for (std::list<TuioPoint>::iterator tpoint = tchg->getPoints().begin(); tpoint!=tchg->getPoints().end(); tpoint++) {
+		(*oscPacket) << tpoint->getX() << tpoint->getY();
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
+void TuioServer::addOCGMessage(TuioGeometry *tocg) {
+	checkBundleCapacity(OCG_MESSAGE_SIZE + 8 * tocg->getPoints().size());
+	
+	(*oscPacket) << osc::BeginMessage( "/tuio2/ocg");
+	(*oscPacket) << (int32)tocg->getSessionID();
+	for (std::list<TuioPoint>::iterator tpoint = tocg->getPoints().begin(); tpoint!=tocg->getPoints().end(); tpoint++) {
+		(*oscPacket) << tpoint->getX() << tpoint->getY();
+	}
+	(*oscPacket) << osc::EndMessage;
+}
+
 void TuioServer::sendTuioBundle() {
     
     //int before = oscPacket->Capacity()-oscPacket->Size();

--- a/TUIO2/TuioServer.h
+++ b/TUIO2/TuioServer.h
@@ -35,6 +35,8 @@
 #define BND_MESSAGE_SIZE 116
 #define SYM_MESSAGE_SIZE 116
 #define ALV_MESSAGE_SIZE 20
+#define CHG_MESSAGE_SIZE 24
+#define OCG_MESSAGE_SIZE 24
 
 namespace TUIO2 {
 	/**
@@ -198,6 +200,8 @@ namespace TUIO2 {
         void addPointerMessage(TuioPointer *tptr);
         void addBoundsMessage(TuioBounds *tbnd);
         void addSymbolMessage(TuioSymbol *tsym);
+		void addCHGMessage(TuioGeometry *tchg);
+		void addOCGMessage(TuioGeometry *tocg);
 		void sendTuioBundle();
         void sendEmptyTuioBundle();
 		


### PR DESCRIPTION
I have implemented the /tuio2/chg and /tuio2/ocg via a new TuioGeometry class, that contains a list of points defining the object geometry. It can be subclassed to support more complex geometry messages, such as /tuio2/ocg for example.
The TuioClient and TuioServer are modified to support the new messages.
